### PR TITLE
Avoid mutation when sanitizing a given body

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It is used like any other Express middleware. More info can be found [on the Exp
 
 It's recommended to use this at the finest level possible, i.e. only on the routes needed.
 
-### `sanitize(sanitizeOn: string[] | string, positive: boolean = false)`
+### `sanitize(sanitizeOn: string[] | string, positive: boolean)`
 This will remove any properties defined by `sanitizeOn` from the response body object sent with [`res.json`](https://expressjs.com/en/4x/api.html#res.json).
 
 #### `sanitizeOn`
@@ -30,29 +30,10 @@ The "direction" to sanitize. Positive sanitization will __*keep*__ the given key
 
 # Example
 This is an example of how to use this on the route-level of an Express app.
-
-## TypeScript
 ```ts
 import { Router } from 'express';
 import { sanitize } from 'sanitware';
 // ...
-
-const myCoolRoutes = Router();
-const removeKeys: string[] = [
-    'password',
-    'PII',
-    // etc...?
-];
-myCoolRoutes.use(sanitizer(removeKeys));
-// ...
-
-// routes, exports, etc...
-```
-
-## JavaScript
-```js
-const Router = require('express').Router;
-const sanitize = require('sanitware');
 
 const myCoolRoutes = Router();
 const removeKeys = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "express-sanitizer",
+  "name": "sanitware",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "express-sanitizer",
+      "name": "sanitware",
       "version": "0.1.0",
       "license": "MPL-2.0",
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sanitware",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sanitware",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MPL-2.0",
       "devDependencies": {
         "@babel/core": "^7.21.8",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "express-sanitizer",
+  "name": "sanitware",
   "version": "0.1.0",
   "description": "Express middleware to sanitize JSON responses",
   "main": "dist/index.js",
@@ -9,7 +9,7 @@
     "clean": "rm -rf dist",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "lint": "eslint -p tsconfig.json",
-    "postversion":"git push && git push --tags",
+    "postversion": "git push && git push --tags",
     "prepare": "npm run build",
     "prepublishOnly": "npm test && npm run lint",
     "preversion": "npm run lint",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc",
     "clean": "rm -rf dist",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
-    "lint": "eslint -p tsconfig.json",
+    "lint": "eslint",
     "postversion": "git push && git push --tags",
     "prepare": "npm run build",
     "prepublishOnly": "npm test && npm run lint",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanitware",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Express middleware to sanitize JSON responses",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/lib/helpers/version-checks.ts
+++ b/src/lib/helpers/version-checks.ts
@@ -1,15 +1,15 @@
 import { version } from 'process';
 
 interface Version {
-    major: string;
-    minor: string;
-    patch: string;
+  major: string;
+  minor: string;
+  patch: string;
 }
 
 const EARLIEST_SUPPORTED_VERSION: Version = {
-    major: "17",
-    minor: "0",
-    patch: "29"
+  major: '17',
+  minor: '0',
+  patch: '29',
 };
 
 /**
@@ -17,12 +17,12 @@ const EARLIEST_SUPPORTED_VERSION: Version = {
  * @returns True if the current Node version is supported, false otherwise
  */
 function checkCompatibility(): boolean {
-    const currVer: Version = getCurrVer();
-    return (
-        EARLIEST_SUPPORTED_VERSION.major <= currVer.major &&
-        EARLIEST_SUPPORTED_VERSION.minor <= currVer.minor &&
-        EARLIEST_SUPPORTED_VERSION.patch <= currVer.patch
-    );    
+  const currVer: Version = getCurrVer();
+  return (
+    EARLIEST_SUPPORTED_VERSION.major <= currVer.major &&
+    EARLIEST_SUPPORTED_VERSION.minor <= currVer.minor &&
+    EARLIEST_SUPPORTED_VERSION.patch <= currVer.patch
+  );
 }
 
 /**
@@ -30,16 +30,16 @@ function checkCompatibility(): boolean {
  * @returns The current Node version as a Version object
  */
 function getCurrVer(): Version {
-    const verRegex: RegExp = /^v(?<major>\d*).(?<minor>\d*).(?<patch>\d*)$/;
-    const currVer = verRegex.exec(version);
+  const verRegex: RegExp = /^v(?<major>\d*).(?<minor>\d*).(?<patch>\d*)$/;
+  const currVer = verRegex.exec(version);
 
-    if (!currVer || !currVer.groups) {
-        throw new Error('Unable to parse Node version');
-    }
+  if (!currVer || !currVer.groups) {
+    throw new Error('Unable to parse Node version');
+  }
 
-    console.log(currVer);
+  console.log(currVer);
 
-    return (currVer.groups as unknown) as Version;
+  return currVer.groups as unknown as Version;
 }
 
 export { checkCompatibility };

--- a/src/lib/helpers/version-checks.ts
+++ b/src/lib/helpers/version-checks.ts
@@ -1,0 +1,45 @@
+import { version } from 'process';
+
+interface Version {
+    major: string;
+    minor: string;
+    patch: string;
+}
+
+const EARLIEST_SUPPORTED_VERSION: Version = {
+    major: "17",
+    minor: "0",
+    patch: "29"
+};
+
+/**
+ * Check the current Node version against the earliest supported version.
+ * @returns True if the current Node version is supported, false otherwise
+ */
+function checkCompatibility(): boolean {
+    const currVer: Version = getCurrVer();
+    return (
+        EARLIEST_SUPPORTED_VERSION.major <= currVer.major &&
+        EARLIEST_SUPPORTED_VERSION.minor <= currVer.minor &&
+        EARLIEST_SUPPORTED_VERSION.patch <= currVer.patch
+    );    
+}
+
+/**
+ * Get the current Node version as a Version object.
+ * @returns The current Node version as a Version object
+ */
+function getCurrVer(): Version {
+    const verRegex: RegExp = /^v(?<major>\d*).(?<minor>\d*).(?<patch>\d*)$/;
+    const currVer = verRegex.exec(version);
+
+    if (!currVer || !currVer.groups) {
+        throw new Error('Unable to parse Node version');
+    }
+
+    console.log(currVer);
+
+    return (currVer.groups as unknown) as Version;
+}
+
+export { checkCompatibility };

--- a/src/lib/sanitizer.ts
+++ b/src/lib/sanitizer.ts
@@ -44,13 +44,12 @@ function sanitize(sanitizeOn: string[] | string, positive = false) {
   return (req: Request, res: Response, next: NextFunction) => {
     const _json = res.json;
     res.json = function (body: unknown): Response {
-      if (!body || body.constructor !== Object) {
+      if (!body || typeof body !== 'object') {
         _json.call(this, body);
         return res;
       }
 
       const sanitizedBody = sanitizer(clone(body), sanitizeOn, positive);
-      console.log(sanitizedBody);
       _json.call(this, sanitizedBody);
       return res;
     };

--- a/src/lib/sanitizer.ts
+++ b/src/lib/sanitizer.ts
@@ -1,4 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
+import { checkCompatibility } from './helpers/version-checks';
 
 interface GenObj {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -23,7 +24,7 @@ function sanitizer(body: GenObj, sanitizeOn: string[] | string, positive = false
   keys.forEach((key) => {
     if (direction(key)) {
       delete body[key];
-    } else if (body[key] && body[key]?.constructor === Object) {
+    } else if (body[key] && typeof body[key] === 'object') {
       body[key] = sanitizer(body[key], sanitizeOn, positive);
     }
   });
@@ -48,7 +49,7 @@ function sanitize(sanitizeOn: string[] | string, positive = false) {
         return res;
       }
 
-      const sanitizedBody = sanitizer(body, sanitizeOn, positive);
+      const sanitizedBody = sanitizer(clone(body), sanitizeOn, positive);
       console.log(sanitizedBody);
       _json.call(this, sanitizedBody);
       return res;
@@ -57,4 +58,18 @@ function sanitize(sanitizeOn: string[] | string, positive = false) {
   };
 }
 
-export { sanitizer, sanitize };
+/**
+ * Clone a given object based on Node.js version.
+ * (Prefer `structuredClone` if available.)
+ * @param obj The object to clone
+ * @returns The cloned object
+ */
+function clone(obj: object): object {
+  if (checkCompatibility()) {
+    return structuredClone(obj);
+  } else {
+    return JSON.parse(JSON.stringify(obj));
+  }
+}
+
+export { sanitize, sanitizer };

--- a/test/sanitizer.test.ts
+++ b/test/sanitizer.test.ts
@@ -1,30 +1,82 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, expect, test } from '@jest/globals';
 import { sanitizer } from '../src/lib/sanitizer';
-import { testA } from './test-objects';
+import { testUserA, testUserB, testUserC, testUserD, userArr } from './test-objects';
 
 describe('Sanitizer', () => {
   const sanitizeOn: string[] = ['username', 'blahblah'];
-
-  test('Sanitizer keeps only the `username` and `blahblah` keys', () => {
-    const expectedObj = { ...testA } as any;
+  
+  test('Sanitizer keeps only the username and blahblah keys', () => {
+    const expectedObj = { ...testUserA } as any;
     delete expectedObj.password;
-
-    expect(sanitizer(testA, sanitizeOn, true)).toEqual(expectedObj);
+    
+    expect(sanitizer(structuredClone(testUserA), sanitizeOn, true)).toEqual(expectedObj);
+    expect(testUserA).toEqual(testUserA);
   });
 
-  test('Sanitizer removes the `username` and `blahblah` keys', () => {
-    const expectedObj = { ...testA } as any;
+  test('Should not remove a non-existent key', () => {
+    expect(sanitizer(structuredClone(testUserA), 'nonexistentkey')).toEqual(testUserA);
+    expect(testUserA).toEqual(testUserA);
+  });
+  
+  test('Sanitizer removes the username and blahblah keys', () => {
+    const expectedObj = { ...testUserA } as any;
     delete expectedObj.username;
     delete expectedObj.blahblah;
-
-    expect(sanitizer(testA, sanitizeOn, false)).toEqual(expectedObj);
+    
+    expect(sanitizer(structuredClone(testUserA), sanitizeOn, false)).toEqual(expectedObj);
+    expect(testUserA).toEqual(testUserA);
   });
-
-  test('Sanitizer removes the `password` key', () => {
-    const expectedObj = { ...testA } as any;
+  
+  test('Sanitizer removes the password key', () => {
+    const expectedObj = { ...testUserA } as any;
     delete expectedObj.password;
+    
+    expect(sanitizer(structuredClone(testUserA), 'password')).toEqual(expectedObj);
+    expect(testUserA).toEqual(testUserA);
+  });
+  
+  test('Should remove the password key from parent and all children objects', () => {
+    const expectedObj = {
+      ...testUserC
+    } as any;
+    delete expectedObj.password;
+    delete expectedObj.friends.password;
+    const result = sanitizer(structuredClone(testUserC), 'password');
+    
+    expect(result).toEqual(expectedObj);
+    expect(testUserC).toEqual(testUserC);
+  });
+  
+  test('Should remove the password key from every member of array prop', () => {
+    const expectedObj = { ...testUserD };
+    delete expectedObj.password;
+    if (Array.isArray(expectedObj.friends)) {
+      expectedObj.friends.forEach((friend) => {
+        delete friend.password;
+      });
+    }
+    
+    const result = sanitizer(structuredClone(testUserD), 'password');
+    expect(result).toEqual(expectedObj);
+    expect(testUserD).toEqual(testUserD);
+  });
+  
+  test('Should remove the password key from all array object elements', () => {
+    const expectedArr = [
+      {
+        username: 'Peter Parker',
+        blahblah: false
+      },
+      {
+        username: 'Miles Morales',
+        blahblah: true
+      },
+    ];
+    
+    const result = sanitizer(structuredClone(userArr), 'password');
 
-    expect(sanitizer(testA, 'password')).toEqual(expectedObj);
+    expect(result).toEqual(expectedArr);
+    expect(userArr).toEqual(userArr);
   });
 });

--- a/test/sanitizer.test.ts
+++ b/test/sanitizer.test.ts
@@ -5,11 +5,11 @@ import { testUserA, testUserB, testUserC, testUserD, userArr } from './test-obje
 
 describe('Sanitizer', () => {
   const sanitizeOn: string[] = ['username', 'blahblah'];
-  
+
   test('Sanitizer keeps only the username and blahblah keys', () => {
     const expectedObj = { ...testUserA } as any;
     delete expectedObj.password;
-    
+
     expect(sanitizer(structuredClone(testUserA), sanitizeOn, true)).toEqual(expectedObj);
     expect(testUserA).toEqual(testUserA);
   });
@@ -18,36 +18,36 @@ describe('Sanitizer', () => {
     expect(sanitizer(structuredClone(testUserA), 'nonexistentkey')).toEqual(testUserA);
     expect(testUserA).toEqual(testUserA);
   });
-  
+
   test('Sanitizer removes the username and blahblah keys', () => {
     const expectedObj = { ...testUserA } as any;
     delete expectedObj.username;
     delete expectedObj.blahblah;
-    
+
     expect(sanitizer(structuredClone(testUserA), sanitizeOn, false)).toEqual(expectedObj);
     expect(testUserA).toEqual(testUserA);
   });
-  
+
   test('Sanitizer removes the password key', () => {
     const expectedObj = { ...testUserA } as any;
     delete expectedObj.password;
-    
+
     expect(sanitizer(structuredClone(testUserA), 'password')).toEqual(expectedObj);
     expect(testUserA).toEqual(testUserA);
   });
-  
+
   test('Should remove the password key from parent and all children objects', () => {
     const expectedObj = {
-      ...testUserC
+      ...testUserC,
     } as any;
     delete expectedObj.password;
     delete expectedObj.friends.password;
     const result = sanitizer(structuredClone(testUserC), 'password');
-    
+
     expect(result).toEqual(expectedObj);
     expect(testUserC).toEqual(testUserC);
   });
-  
+
   test('Should remove the password key from every member of array prop', () => {
     const expectedObj = { ...testUserD };
     delete expectedObj.password;
@@ -56,24 +56,24 @@ describe('Sanitizer', () => {
         delete friend.password;
       });
     }
-    
+
     const result = sanitizer(structuredClone(testUserD), 'password');
     expect(result).toEqual(expectedObj);
     expect(testUserD).toEqual(testUserD);
   });
-  
+
   test('Should remove the password key from all array object elements', () => {
     const expectedArr = [
       {
         username: 'Peter Parker',
-        blahblah: false
+        blahblah: false,
       },
       {
         username: 'Miles Morales',
-        blahblah: true
+        blahblah: true,
       },
     ];
-    
+
     const result = sanitizer(structuredClone(userArr), 'password');
 
     expect(result).toEqual(expectedArr);

--- a/test/test-objects.ts
+++ b/test/test-objects.ts
@@ -1,10 +1,39 @@
-const testA = {
+interface User {
+    username: string;
+    password?: string;
+    blahblah?: boolean;
+    friends?: User | User[];
+}
+
+const testUserA: User = {
     username: 'Peter Parker',
     password: 'spiderman15cool!',
     blahblah: false
 };
+const testUserB: User = {
+    username: 'Miles Morales',
+    password: 'imcoolersp1d3rm4n!!',
+    blahblah: true
+};
+const testUserC: User = {
+    username: 'g4nke',
+    password: 'websh00terz',
+    friends: testUserB,
+};
+const testUserD: User = {
+    username: 'octavius',
+    password: 'octopiiRawsum',
+    friends: [{ ...testUserB }, { ...testUserA }, { ...testUserC }],
+};
+const userArr = [
+    testUserA,
+    testUserB,
+];
 
 export {
-    testA,
-    
+    testUserA,
+    testUserB,
+    testUserC,
+    testUserD,
+    userArr,    
 }

--- a/test/test-objects.ts
+++ b/test/test-objects.ts
@@ -1,39 +1,30 @@
 interface User {
-    username: string;
-    password?: string;
-    blahblah?: boolean;
-    friends?: User | User[];
+  username: string;
+  password?: string;
+  blahblah?: boolean;
+  friends?: User | User[];
 }
 
 const testUserA: User = {
-    username: 'Peter Parker',
-    password: 'spiderman15cool!',
-    blahblah: false
+  username: 'Peter Parker',
+  password: 'spiderman15cool!',
+  blahblah: false,
 };
 const testUserB: User = {
-    username: 'Miles Morales',
-    password: 'imcoolersp1d3rm4n!!',
-    blahblah: true
+  username: 'Miles Morales',
+  password: 'imcoolersp1d3rm4n!!',
+  blahblah: true,
 };
 const testUserC: User = {
-    username: 'g4nke',
-    password: 'websh00terz',
-    friends: testUserB,
+  username: 'g4nke',
+  password: 'websh00terz',
+  friends: testUserB,
 };
 const testUserD: User = {
-    username: 'octavius',
-    password: 'octopiiRawsum',
-    friends: [{ ...testUserB }, { ...testUserA }, { ...testUserC }],
+  username: 'octavius',
+  password: 'octopiiRawsum',
+  friends: [{ ...testUserB }, { ...testUserA }, { ...testUserC }],
 };
-const userArr = [
-    testUserA,
-    testUserB,
-];
+const userArr = [testUserA, testUserB];
 
-export {
-    testUserA,
-    testUserB,
-    testUserC,
-    testUserD,
-    userArr,    
-}
+export { testUserA, testUserB, testUserC, testUserD, userArr };

--- a/test/version-checks.test.ts
+++ b/test/version-checks.test.ts
@@ -1,0 +1,7 @@
+import { checkCompatibility } from "../src/lib/helpers/version-checks";
+
+describe("version-checks", () => {
+    test('should return true if the versions are compatible', () => {
+        expect(checkCompatibility()).toBe(true);
+    });
+});


### PR DESCRIPTION
This will prevent object mutation when sanitizing a given object using either `structuredClone` or JSON string/parse hack.

